### PR TITLE
fix: Use dual-canvas approach for thumbnail generation

### DIFF
--- a/src/lib/thumbnail.ts
+++ b/src/lib/thumbnail.ts
@@ -1,8 +1,8 @@
 /**
  * Thumbnail Generation for KiCanvas Viewer
  *
- * Captures screenshots of the KiCanvas viewer in both light and dark modes
- * Uses html2canvas for client-side screenshot generation
+ * Captures screenshots of two KiCanvas viewers (light and dark themes)
+ * Uses native canvas export with html2canvas fallback
  */
 
 import html2canvas from 'html2canvas';
@@ -18,14 +18,17 @@ export const THUMBNAIL_CONFIG = {
 
 export const RENDER_CONFIG = {
   RENDER_TIMEOUT: 10000, // Max time to wait for render event (ms)
-  THEME_SWITCH_WAIT: 1000, // Max time to wait for theme switch (ms)
-  THEME_POLL_INTERVAL: 50, // How often to check theme (ms)
   OVERLAY_DISMISS_WAIT: 100, // Time to wait after dismissing overlay (ms)
+  CANVAS_WAIT_ATTEMPTS: 5, // Number of attempts to wait for canvas
+  CANVAS_WAIT_DELAY: 200, // Delay between canvas wait attempts (ms)
 } as const;
 
 // For backwards compatibility
 export const THUMBNAIL_WIDTH = THUMBNAIL_CONFIG.WIDTH;
 export const THUMBNAIL_HEIGHT = THUMBNAIL_CONFIG.HEIGHT;
+
+// KiCanvas error color (cyan/teal when rendering fails)
+const KICANVAS_ERROR_COLOR = { r: 0, g: 255, b: 255 }; // #00FFFF
 
 export interface ThumbnailResult {
   light: string; // base64 data URL
@@ -33,180 +36,157 @@ export interface ThumbnailResult {
 }
 
 /**
- * Wait for KiCanvas to be ready and fully rendered
- * Listens for the 'kicanvas:render' event which fires after the first frame is drawn
+ * Check if a canvas is mostly the KiCanvas cyan error color
+ * Returns true if the image appears to be invalid/error state
  */
-async function waitForKiCanvasReady(element: HTMLElement): Promise<void> {
-  console.log('Waiting for KiCanvas to render...');
+function isInvalidCapture(canvas: HTMLCanvasElement): boolean {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return true;
+
+  // Sample pixels at various points across the canvas
+  const samplePoints = [
+    { x: 10, y: 10 },
+    { x: canvas.width / 2, y: canvas.height / 2 },
+    { x: canvas.width - 10, y: 10 },
+    { x: 10, y: canvas.height - 10 },
+    { x: canvas.width - 10, y: canvas.height - 10 },
+    { x: canvas.width / 4, y: canvas.height / 4 },
+    { x: (canvas.width * 3) / 4, y: (canvas.height * 3) / 4 },
+    { x: canvas.width / 3, y: canvas.height / 2 },
+    { x: (canvas.width * 2) / 3, y: canvas.height / 2 },
+  ];
+
+  let cyanCount = 0;
+
+  for (const point of samplePoints) {
+    const pixel = ctx.getImageData(Math.floor(point.x), Math.floor(point.y), 1, 1).data;
+    const color = { r: pixel[0], g: pixel[1], b: pixel[2] };
+
+    // Check if this pixel is the cyan error color (with some tolerance)
+    // KiCanvas error cyan is exactly #00FFFF (0, 255, 255)
+    if (color.r < 20 && color.g > 240 && color.b > 240) {
+      cyanCount++;
+    }
+  }
+
+  // Only flag as invalid if MOST samples are the specific cyan error color
+  if (cyanCount >= samplePoints.length - 1) {
+    console.log('[Capture] Detected cyan error color - invalid capture');
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Recursively search for canvas in shadow DOMs (up to maxDepth levels)
+ */
+function findCanvasInShadowDOM(root: Element | ShadowRoot, depth = 0, maxDepth = 5): HTMLCanvasElement | null {
+  if (depth > maxDepth) return null;
+
+  // Check for canvas directly
+  const canvas = root.querySelector('canvas');
+  if (canvas) {
+    console.log(`[FindCanvas] Found canvas at depth ${depth}`);
+    return canvas;
+  }
+
+  // Search in shadow roots of all elements
+  const elements = root.querySelectorAll('*');
+  for (const el of Array.from(elements)) {
+    if (el.shadowRoot) {
+      const found = findCanvasInShadowDOM(el.shadowRoot, depth + 1, maxDepth);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find the canvas element inside kicanvas-embed (may be in shadow DOM)
+ */
+function findKiCanvasCanvas(kicanvasEmbed: Element): HTMLCanvasElement | null {
+  // Try direct child first
+  const directCanvas = kicanvasEmbed.querySelector('canvas');
+  if (directCanvas) {
+    return directCanvas;
+  }
+
+  // Try shadow DOM recursively
+  if (kicanvasEmbed.shadowRoot) {
+    const shadowCanvas = findCanvasInShadowDOM(kicanvasEmbed.shadowRoot, 0);
+    if (shadowCanvas) return shadowCanvas;
+  }
+
+  // Try to find kicanvas-viewer or kicanvas-schematic inside
+  const viewers = ['kicanvas-viewer', 'kicanvas-schematic', 'kicanvas-app'];
+  for (const viewerTag of viewers) {
+    let viewer = kicanvasEmbed.querySelector(viewerTag);
+    if (!viewer && kicanvasEmbed.shadowRoot) {
+      viewer = kicanvasEmbed.shadowRoot.querySelector(viewerTag);
+    }
+    if (viewer) {
+      if (viewer.shadowRoot) {
+        const viewerCanvas = findCanvasInShadowDOM(viewer.shadowRoot, 0);
+        if (viewerCanvas) return viewerCanvas;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Wait for a canvas to be ready with retries
+ */
+async function waitForCanvas(
+  kicanvasEmbed: Element,
+  mode: string
+): Promise<HTMLCanvasElement | null> {
+  for (let attempt = 1; attempt <= RENDER_CONFIG.CANVAS_WAIT_ATTEMPTS; attempt++) {
+    const canvas = findKiCanvasCanvas(kicanvasEmbed);
+    if (canvas && canvas.width > 0 && canvas.height > 0) {
+      console.log(`[Capture] ${mode}: Canvas ready on attempt ${attempt}: ${canvas.width}x${canvas.height}`);
+      return canvas;
+    }
+    console.log(`[Capture] ${mode}: Attempt ${attempt}/${RENDER_CONFIG.CANVAS_WAIT_ATTEMPTS} - canvas not ready yet`);
+    await new Promise(resolve => setTimeout(resolve, RENDER_CONFIG.CANVAS_WAIT_DELAY));
+  }
+  return null;
+}
+
+/**
+ * Capture a single KiCanvas viewer element using native canvas export
+ */
+async function captureKiCanvasElement(
+  containerElement: HTMLElement,
+  mode: 'light' | 'dark' = 'light'
+): Promise<string> {
+  console.log(`[Capture] Starting ${mode} mode capture...`);
 
   // Find the kicanvas-embed element
-  const kicanvasEmbed = element.querySelector('kicanvas-embed');
+  const kicanvasEmbed = containerElement.querySelector('kicanvas-embed');
   if (!kicanvasEmbed) {
-    throw new Error('kicanvas-embed element not found');
+    console.error(`[Capture] ${mode}: kicanvas-embed element not found`);
+    throw new Error('kicanvas-embed element not found in container');
   }
 
-  // Check if already rendered (in case the event already fired)
-  if (kicanvasEmbed.hasAttribute('rendered')) {
-    console.log('KiCanvas already rendered');
-    return;
-  }
+  // Try to click to dismiss any overlay
+  (kicanvasEmbed as HTMLElement).click();
+  await new Promise(resolve => setTimeout(resolve, RENDER_CONFIG.OVERLAY_DISMISS_WAIT));
 
-  // Wait for the kicanvas:render event with timeout
-  const renderPromise = new Promise<void>((resolve) => {
-    kicanvasEmbed.addEventListener('kicanvas:render', () => {
-      console.log('KiCanvas render event received');
-      resolve();
-    }, { once: true });
-  });
+  // Try to find and capture the canvas with retries
+  const sourceCanvas = await waitForCanvas(kicanvasEmbed, mode);
+  console.log(`[Capture] ${mode}: Final canvas state:`, !!sourceCanvas, sourceCanvas ? `${sourceCanvas.width}x${sourceCanvas.height}` : 'N/A');
 
-  const timeoutPromise = new Promise<void>((_, reject) => {
-    setTimeout(() => {
-      reject(new Error(`KiCanvas render timeout after ${RENDER_CONFIG.RENDER_TIMEOUT}ms`));
-    }, RENDER_CONFIG.RENDER_TIMEOUT);
-  });
+  if (sourceCanvas && sourceCanvas.width > 0 && sourceCanvas.height > 0) {
+    console.log('[Capture] Using native canvas export');
 
-  await Promise.race([renderPromise, timeoutPromise]);
-  console.log('KiCanvas render complete');
-}
-
-/**
- * Wait for theme to be applied to the document
- */
-async function waitForThemeApplied(expectedTheme: 'light' | 'dark'): Promise<void> {
-  const startTime = Date.now();
-
-  while (Date.now() - startTime < RENDER_CONFIG.THEME_SWITCH_WAIT) {
-    const currentTheme = document.documentElement.getAttribute('data-theme') ||
-      document.documentElement.className.includes('dark') ? 'dark' : 'light';
-
-    if (currentTheme === expectedTheme) {
-      console.log(`Theme switched to ${expectedTheme} after ${Date.now() - startTime}ms`);
-      return;
-    }
-
-    await new Promise(resolve => setTimeout(resolve, RENDER_CONFIG.THEME_POLL_INTERVAL));
-  }
-
-  // Log warning but don't fail - theme might be applied differently
-  console.warn(`Theme did not switch to ${expectedTheme} within ${RENDER_CONFIG.THEME_SWITCH_WAIT}ms`);
-}
-
-/**
- * Generate light mode thumbnail from dark mode by inverting colors
- * Creates a lighter, inverted version suitable for light themes
- */
-function generateLightFromDark(darkDataURL: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-
-    img.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = img.width;
-      canvas.height = img.height;
-
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        reject(new Error('Could not get canvas context'));
-        return;
-      }
-
-      // Draw the dark image
-      ctx.drawImage(img, 0, 0);
-
-      // Get image data
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      const data = imageData.data;
-
-      // Invert colors (skip alpha channel)
-      for (let i = 0; i < data.length; i += 4) {
-        data[i] = 255 - data[i];         // Red
-        data[i + 1] = 255 - data[i + 1]; // Green
-        data[i + 2] = 255 - data[i + 2]; // Blue
-        // data[i + 3] is alpha, keep unchanged
-      }
-
-      // Put the inverted data back
-      ctx.putImageData(imageData, 0, 0);
-
-      // Convert to data URL
-      resolve(canvas.toDataURL('image/png', 0.9));
-    };
-
-    img.onerror = () => {
-      reject(new Error('Failed to load image for light mode generation'));
-    };
-
-    img.src = darkDataURL;
-  });
-}
-
-/**
- * Capture a screenshot of the KiCanvas element
- * Uses html2canvas with WebGL preservation
- */
-async function captureElement(element: HTMLElement): Promise<string> {
-  try {
-    // Find the kicanvas-embed element and trigger interaction to remove overlay
-    const kicanvasEmbed = element.querySelector('kicanvas-embed') as any;
-    if (kicanvasEmbed) {
-      // Simulate a click to activate the viewer and dismiss overlay
-      kicanvasEmbed.click();
-      // Wait a bit for the overlay to disappear
-      await new Promise(resolve => setTimeout(resolve, RENDER_CONFIG.OVERLAY_DISMISS_WAIT));
-    }
-
-    // Hide overlay if it exists
-    const overlay = element.querySelector('.kc-overlay') as HTMLElement;
-    const originalDisplay = overlay?.style.display;
-    if (overlay) {
-      overlay.style.display = 'none';
-    }
-
-    // Use html2canvas but make sure we're capturing the right element
-    // KiCanvas renders in shadow DOM, which html2canvas can't capture
-    // So we need to use a different approach - capture using browser's native API
-    const sourceCanvas = await html2canvas(element, {
-      backgroundColor: null,
-      scale: THUMBNAIL_CONFIG.SCALE,
-      logging: true,
-      useCORS: true,
-      allowTaint: true,
-      foreignObjectRendering: false, // Disable to avoid issues with shadow DOM
-      width: element.scrollWidth,
-      height: element.scrollHeight,
-    });
-
-    // Restore overlay
-    if (overlay && originalDisplay !== undefined) {
-      overlay.style.display = originalDisplay;
-    }
-
-    console.log(`Captured canvas: ${sourceCanvas.width}x${sourceCanvas.height}`);
-
-    // Validate canvas dimensions
-    if (sourceCanvas.width === 0 || sourceCanvas.height === 0) {
-      throw new Error(`Canvas has invalid dimensions: ${sourceCanvas.width}x${sourceCanvas.height}. Element may not be visible or rendered.`);
-    }
-
-    // Instead of resizing to fixed dimensions with letterboxing,
-    // we'll crop the canvas to fit the target aspect ratio and then scale
-    const targetAspectRatio = THUMBNAIL_CONFIG.WIDTH / THUMBNAIL_CONFIG.HEIGHT;
-    const sourceAspectRatio = sourceCanvas.width / sourceCanvas.height;
-
-    let cropWidth = sourceCanvas.width;
-    let cropHeight = sourceCanvas.height;
-    let cropX = 0;
-    let cropY = 0;
-
-    // Crop to match target aspect ratio
-    if (sourceAspectRatio > targetAspectRatio) {
-      // Source is wider - crop width
-      cropWidth = sourceCanvas.height * targetAspectRatio;
-      cropX = (sourceCanvas.width - cropWidth) / 2;
-    } else if (sourceAspectRatio < targetAspectRatio) {
-      // Source is taller - crop height
-      cropHeight = sourceCanvas.width / targetAspectRatio;
-      cropY = (sourceCanvas.height - cropHeight) / 2;
+    // Check if source canvas is valid (not cyan error color)
+    if (isInvalidCapture(sourceCanvas)) {
+      console.error(`[Capture] ${mode}: Source canvas appears to be error state (cyan)`);
+      throw new Error('Canvas shows error state (cyan color)');
     }
 
     // Create output canvas at target dimensions
@@ -219,76 +199,97 @@ async function captureElement(element: HTMLElement): Promise<string> {
       throw new Error('Could not get canvas context');
     }
 
-    // Draw the cropped and scaled image directly from the source canvas
+    // Draw the source canvas scaled to target dimensions
     ctx.drawImage(
       sourceCanvas,
-      cropX, cropY, cropWidth, cropHeight,  // Source rectangle (cropped)
-      0, 0, THUMBNAIL_CONFIG.WIDTH, THUMBNAIL_CONFIG.HEIGHT  // Destination rectangle (full canvas)
+      0, 0, sourceCanvas.width, sourceCanvas.height,
+      0, 0, THUMBNAIL_CONFIG.WIDTH, THUMBNAIL_CONFIG.HEIGHT
     );
 
-    console.log(`Captured and resized to ${THUMBNAIL_CONFIG.WIDTH}x${THUMBNAIL_CONFIG.HEIGHT}`);
-
     return resizedCanvas.toDataURL('image/png', THUMBNAIL_CONFIG.QUALITY);
-  } catch (err) {
-    console.error('Screenshot capture failed:', err);
-    throw new Error(`Failed to capture screenshot: ${err instanceof Error ? err.message : 'Unknown error'}`);
   }
+
+  // Fallback to html2canvas
+  console.log('[Capture] Falling back to html2canvas');
+  const capturedCanvas = await html2canvas(containerElement, {
+    backgroundColor: null,
+    scale: THUMBNAIL_CONFIG.SCALE,
+    logging: false,
+    useCORS: true,
+    allowTaint: true,
+    foreignObjectRendering: false,
+    width: containerElement.scrollWidth,
+    height: containerElement.scrollHeight,
+  });
+
+  if (capturedCanvas.width === 0 || capturedCanvas.height === 0) {
+    throw new Error('Captured canvas has zero dimensions');
+  }
+
+  // Check if html2canvas result is valid (not cyan error color)
+  if (isInvalidCapture(capturedCanvas)) {
+    console.error(`[Capture] ${mode}: html2canvas result appears to be error state (cyan)`);
+    throw new Error('Canvas shows error state (cyan color)');
+  }
+
+  // Create output canvas at target dimensions
+  const resizedCanvas = document.createElement('canvas');
+  resizedCanvas.width = THUMBNAIL_CONFIG.WIDTH;
+  resizedCanvas.height = THUMBNAIL_CONFIG.HEIGHT;
+
+  const ctx = resizedCanvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Could not get canvas context');
+  }
+
+  ctx.drawImage(
+    capturedCanvas,
+    0, 0, capturedCanvas.width, capturedCanvas.height,
+    0, 0, THUMBNAIL_CONFIG.WIDTH, THUMBNAIL_CONFIG.HEIGHT
+  );
+
+  return resizedCanvas.toDataURL('image/png', THUMBNAIL_CONFIG.QUALITY);
 }
 
 /**
- * Capture thumbnail in dark mode only and generate light mode programmatically
+ * Capture both light and dark KiCanvas viewers
  *
- * Approach:
- * 1. Ensure we're in dark mode
- * 2. Wait for theme to apply (smart polling)
- * 3. Wait for KiCanvas to fully render (smart polling with pixel validation)
- * 4. Capture dark mode screenshot
- * 5. Generate light mode by inverting colors
- * 6. Return both thumbnails
- *
- * This is ~2x faster than capturing both modes separately.
+ * Uses two separate KiCanvas components with fixed themes
+ * (kicad for light, witchhazel for dark) and captures both directly.
  */
 export async function captureThumbnails(
-  kicanvasElement: HTMLElement,
-  currentTheme: 'light' | 'dark',
-  setTheme: (theme: 'light' | 'dark') => void
+  lightContainer: HTMLElement | null,
+  darkContainer: HTMLElement | null
 ): Promise<ThumbnailResult> {
-  try {
-    // Switch to dark mode if not already
-    if (currentTheme !== 'dark') {
-      console.log('Switching to dark mode...');
-      setTheme('dark');
-      // Wait for theme to actually apply
-      await waitForThemeApplied('dark');
+  let light: string | null = null;
+  let dark: string | null = null;
+
+  console.log('[Capture] Starting dual capture, light:', !!lightContainer, 'dark:', !!darkContainer);
+
+  if (lightContainer) {
+    try {
+      light = await captureKiCanvasElement(lightContainer, 'light');
+      console.log('[Capture] Light mode result:', light ? `${light.length} chars` : 'NULL');
+    } catch (err) {
+      console.error('[Capture] Light mode capture failed:', err);
     }
-
-    // Wait for KiCanvas to fully render with smart polling
-    console.log('Waiting for KiCanvas to load...');
-    await waitForKiCanvasReady(kicanvasElement);
-
-    console.log('Capturing dark mode thumbnail...');
-
-    // Capture dark mode screenshot
-    const darkThumb = await captureElement(kicanvasElement);
-
-    console.log('Generating light mode thumbnail from dark mode...');
-
-    // Generate light mode by inverting colors
-    const lightThumb = await generateLightFromDark(darkThumb);
-
-    // Switch back to original theme if needed
-    if (currentTheme === 'light') {
-      console.log('Switching back to light mode...');
-      setTheme('light');
-      await waitForThemeApplied('light');
-    }
-
-    console.log('Thumbnail capture complete!');
-    return { light: lightThumb, dark: darkThumb };
-  } catch (err) {
-    console.error('Thumbnail generation failed:', err);
-    throw err;
   }
+
+  if (darkContainer) {
+    try {
+      dark = await captureKiCanvasElement(darkContainer, 'dark');
+      console.log('[Capture] Dark mode result:', dark ? `${dark.length} chars` : 'NULL');
+    } catch (err) {
+      console.error('[Capture] Dark mode capture failed:', err);
+    }
+  }
+
+  if (!light || !dark) {
+    throw new Error(`Failed to capture thumbnails. Light: ${!!light}, Dark: ${!!dark}`);
+  }
+
+  console.log('[Capture] Dual capture complete!');
+  return { light, dark };
 }
 
 /**


### PR DESCRIPTION
Replace color-inversion hack with proper dual-canvas capture using the modded KiCanvas with theme attribute support. Now renders two separate KiCanvas components (kicad/witchhazel themes) and captures both directly.

- Remove CDN KiCanvas loading from upload page (use local modded version)
- Add explicit theme prop to KiCanvas component
- Update thumbnail.ts with native canvas export from shadow DOM
- Update upload, edit, and admin pages for dual-canvas capture