### PR TITLE
Dynamic sheet size selection for large schematics

### DIFF
--- a/src/lib/kicad-parser.ts
+++ b/src/lib/kicad-parser.ts
@@ -983,3 +983,13 @@ export function removeHierarchicalSheets(sexpr: string): string {
 
   return result;
 }
+
+/**
+ * Replace the paper size in a full KiCad schematic file
+ * Works for both (paper "A4") format and other paper declarations
+ */
+export function replacePaperSize(sexpr: string, newSize: SheetSize): string {
+  // Match (paper "A4") or (paper "A3") etc.
+  const paperRegex = /\(paper\s+"[^"]+"\)/g;
+  return sexpr.replace(paperRegex, `(paper "${newSize}")`);
+}


### PR DESCRIPTION
## Summary
- Automatically selects appropriate sheet size (A4, A3, A2) based on circuit bounding box dimensions
- Adds sheet size indicator/dropdown in upload preview for manual override
- Persists sheet size preference in database for consistent viewing
- Applies sheet size to both clipboard snippets and full .kicad_sch files

Fixes #8

## Test plan
- [ ] Upload a small circuit - should default to A4
- [ ] Upload a large circuit - should auto-detect A3 or A2
- [ ] Override sheet size during upload via dropdown
- [ ] Verify sheet size persists when viewing circuit detail page
- [ ] Edit existing circuit and change sheet size
- [ ] View pre-existing large circuit (e.g., USB hub) - should now display as A3