### PR TITLE
fix: Exclude power symbols from footprint assignment counts

### DIFF
--- a/src/lib/kicad-parser.ts
+++ b/src/lib/kicad-parser.ts
@@ -805,10 +805,18 @@ export function extractMetadata(sexpr: string): ParsedMetadata {
     minX = minY = maxX = maxY = 0;
   }
 
-  // Footprint analysis
+  // Footprint analysis - exclude power symbols (they don't have physical footprints)
   const footprintTypes = new Set<string>();
   let assigned = 0;
+  let totalRequiringFootprints = 0;
+
   for (const comp of components) {
+    // Skip power symbols - they're electrical symbols, not physical components
+    if (comp.lib_id.startsWith("power:")) {
+      continue;
+    }
+
+    totalRequiringFootprints++;
     if (comp.footprint) {
       assigned++;
       footprintTypes.add(comp.footprint);
@@ -832,7 +840,7 @@ export function extractMetadata(sexpr: string): ParsedMetadata {
     },
     footprints: {
       assigned,
-      unassigned: components.length - assigned,
+      unassigned: totalRequiringFootprints - assigned,
       types: Array.from(footprintTypes),
     },
     version,


### PR DESCRIPTION
## Summary
- Power symbols (power:GND, power:VCC, +3.3V, etc.) are now excluded from footprint statistics
- These are electrical connection symbols, not physical components, so they intentionally don't have footprints
- Fixes false "missing footprint" warnings for circuits with power nets

## Test plan
- [x] Verified on Vercel preview deployment
- [x] Existing circuits show corrected counts immediately (metadata calculated on-the-fly)

Fixes #7